### PR TITLE
fixed variable definition in main.tf

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -16,6 +16,6 @@ resource "google_storage_bucket" "bucket" {
 
 resource "google_storage_default_object_acl" "default_obj_acl" {
     bucket = "${google_storage_bucket.bucket.name}"
-    role_entity = ["${var.role_entity}"]
+    role_entity = "${var.role_entity}"
 
 }


### PR DESCRIPTION
Hi, I think I found a minor bug.

I used this module with settings below in `main.tf`, an error occurred.
- Settings in `main.tf`
```
module "google_storage_static_website" {
    source = "../module/terraform-google-storage-static-website"
    bucket_name = ...

    role_entity = ["OWNER:xxx@gmail.com", "READER:yyy@gmail.com"]
}
```
- Error
```
Error: Incorrect attribute value type

  on terraform/module/terraform-google-storage-static-website/main.tf line 19, in resource "google_storage_default_object_acl" "default_obj_acl":
  19:     role_entity = ["${var.role_entity}"]

Inappropriate value for attribute "role_entity": element 0: string required.
```

`${var.role_entity}` is defined as a list, so box brackets are not needed in `main.tf`.
When I fixed it, it worked with no error.

Thank you for your contribution!