### PR TITLE
Updating role_entity to work with default value

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -24,5 +24,5 @@ resource "google_storage_bucket" "this" {
 
 resource "google_storage_default_object_acl" "this" {
   bucket      = google_storage_bucket.this.name
-  role_entity = [var.role_entity]
+  role_entity = var.role_entity
 }


### PR DESCRIPTION
# Updating role_entity to work with default value

When using the module like so:
```
module "google_storage_static_website" {
  source = "jdpleiness/storage-static-website/google"
  bucket_name = var.domain_name
  project = var.project_name
}
```

`terraform validate` will return the following error:
```
$ terraform validate

Error: Incorrect attribute value type

  on .terraform/modules/google_storage_static_website/main.tf line 27, in resource "google_storage_default_object_acl" "this":
  27:   role_entity = [var.role_entity]

Inappropriate value for attribute "role_entity": element 0: string required.
```

The cause seems to be due to a type mismatch issue. In `main.tf`, the module assigns `role_entity` to `[var.role_entity]`, however the default value defined in `variables.tf` is of type `list(string)` with a value of `["READER:allUsers"]`, so when the variable is substituted, it'll be processed as `[ ["READER:allUsers"] ]`.

To fix this, we just need to remove the brackets in `main.tf`, since the variable is already going to be a list.

This was tested with Terraform v0.14.0.