### PR TITLE
Small PR with some convenience fixes 

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This module will create a bucket and assign it the proper ACLs to host a static 
 ```HCL
 module "storage_static_website" {
   source  = "jdpleiness/storage-static-website/google"
-  version = "2.0.0"
+  version = "~> 2.0.0"
 
   bucket_name = "your-website-domain-name"
   project_id  = "your-project-id"

--- a/versions.tf
+++ b/versions.tf
@@ -5,4 +5,10 @@
 
 terraform {
   required_version = ">= 0.12"
+
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
 }


### PR DESCRIPTION
This PR just allows using [alternative provider configuration](https://www.terraform.io/language/providers/configuration) for google. Also adds a pessimistic constraint operator `~>` to the usage example to ensure the latest bugfix version is installed by new users.